### PR TITLE
add Indium

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -86,6 +86,10 @@ metafile = true
 file = "mods/hexxy-dimensions-1.3.0.jar"
 
 [[files]]
+file = "mods/indium.pw.toml"
+metafile = true
+
+[[files]]
 file = "mods/jade-addons-fabric.pw.toml"
 metafile = true
 

--- a/mods/indium.pw.toml
+++ b/mods/indium.pw.toml
@@ -1,0 +1,13 @@
+name = "Indium"
+filename = "indium-1.0.30+mc1.20.4.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/Orvt0mRa/versions/Aouse6P7/indium-1.0.30%2Bmc1.20.4.jar"
+hash-format = "sha1"
+hash = "b24233f29c0ce4802c61ea8998e01e6e4580ae60"
+
+[update]
+[update.modrinth]
+mod-id = "Orvt0mRa"
+version = "Aouse6P7"


### PR DESCRIPTION
Indium is an alternative renderer which is required for certain mods (such as AE2) to function properly with Sodium on Fabric.