### PR TITLE
add AE2 EMI integration mod

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -4,6 +4,10 @@ hash-format = "sha256"
 file = "config/yosbr/options.txt"
 
 [[files]]
+file = "mods/ae2-emi-crafting.pw.toml"
+metafile = true
+
+[[files]]
 file = "mods/ae2.pw.toml"
 metafile = true
 

--- a/mods/ae2-emi-crafting.pw.toml
+++ b/mods/ae2-emi-crafting.pw.toml
@@ -1,0 +1,13 @@
+name = "AE2 EMI Crafting Integration"
+filename = "ae2-emi-crafting-1.3.1.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/eVAp8Nkw/versions/lEmazn2j/ae2-emi-crafting-1.3.1.jar"
+hash-format = "sha1"
+hash = "1a8d8e4a58c9be517c05c14f36c7d663f65a569f"
+
+[update]
+[update.modrinth]
+mod-id = "eVAp8Nkw"
+version = "lEmazn2j"


### PR DESCRIPTION
[AE2 EMI Crafting Integration](https://modrinth.com/mod/ae2-emi-crafting) makes EMI recipe autofill work properly in AE2 terminals (and ae2wtlib wireless terminals)